### PR TITLE
Ubuntu uses differing packages than Debian Wheezy

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,14 @@
 # tasks file for munin.
 
 - name: OS specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+      - "{{ ansible_distribution }}.yml"
+      - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+      - "{{ ansible_os_family }}_family.yml"
+      paths:
+        - "../vars/"
   tags:
     - munin
     - setup

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,17 @@
+---
+munin_master_packages:
+ - munin
+
+munin_node_packages:
+ - munin-node
+ - munin-plugins-extra
+ - libcache-cache-perl
+
+# Variables for munin.conf
+munin_master_htmldir   : /var/cache/munin/www
+munin_master_includedir: /etc/munin/munin-conf.d
+
+# Variables for munin-node.conf
+munin_node_log_file: /var/log/munin/munin-node.log
+munin_node_pid_file: /var/run/munin/munin-node.pid
+


### PR DESCRIPTION
Ubuntu trusty doesn't use munin-cgi or munin-plugins-core.

I didn't see other releases using them either but wasn't thorough.
