### PR TITLE
configure multiple plugins using wildcard without forced symlinking

### DIFF
--- a/library/munin_plugin
+++ b/library/munin_plugin
@@ -10,7 +10,7 @@ options:
     required: True
     aliases: []
   instance:
-    description: Name of the plugin instance. Defaults to {{ name }}. Useful to configure `if_` plugin as `if_eth0`, etc.
+    description: Name of the plugin instance. Defaults to {{ name }}. Useful to configure `if_` plugin as `if_eth0`, etc. If it contains '*', no plugin symlinking will happen, but this will be used as the configuration section's name.
   config:
     description: String of configuration params for the plugin.
   file:


### PR DESCRIPTION
Allow Munin configuration for multiple plugins using wildcard without any symlinking being forced to take place.

This allows the creation of this kind of tasks:
```
- name: Munin ip_* config
  action: munin_plugin
  args:
    instance: ip_*
    name: false
    config: |
      user root
```

This fixed indentation too.