### PR TITLE
fixes sbitio/ansible-munin/issues/6

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,7 +11,7 @@
 - name: Declare node in master
   template: src="munin-host.j2" dest="{{ munin_master_includedir }}/{{ ansible_fqdn }}_{{ munin_node_port }}" backup=no owner=root group=root mode=0644
   delegate_to: "{{ munin_master_ip }}"
-  when: munin_role_node == true
+  when: munin_role_node == true and munin_master_ip != false
 
 - name: Ensure munin-node.conf
   template: src={{ item }} dest={{ munin_node_file_conf }} backup=no owner=root group=root mode=0644


### PR DESCRIPTION
The current configuration do not match some (more and more common) use-cases involving munin-async.
At least with this patch we can skip the node declarations in the master node If munin_master_ip is false, skip the task/don't delegate. This allow better and fine-grained munin-async configuration