### PR TITLE
Added Arch Linux support.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,10 @@ galaxy_info:
   - name: Debian
     versions:
     - Wheezy
+  - name: Archlinux
+    versions:
+    - all
+    - any
   categories:
   - monitoring
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,13 @@
     - munin
     - setup
 
+# Archlinux(setup) specific tasks.
+- include: setup-Archlinux.yml
+  when: "ansible_os_family == 'Archlinux'"
+  tags:
+    - munin
+    - setup
+
 # Common configuration tasks.
 - include: config.yml
   tags:

--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure munin master pacman packages
+  pacman: pkg={{ item }} state={{ munin_package_state }} update_cache=yes
+  with_items: munin_master_packages
+  when: munin_role_master == true
+
+- name: Ensure munin node pacman packages
+  pacman: pkg={{ item }} state={{ munin_package_state }} update_cache=yes
+  with_items: munin_node_packages
+  when: munin_role_node == true
+

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,0 +1,17 @@
+---
+munin_master_packages:
+ - munin
+
+munin_node_packages:
+ - munin-node
+
+# Variables for munin.conf
+munin_master_htmldir   : /usr/share/munin/www
+munin_master_includedir: /etc/munin/munin-conf.d
+
+# Variables for munin-node.conf
+munin_node_log_file: /var/log/munin/munin-node.log
+munin_node_pid_file: /var/run/munin/munin-node.pid
+
+munin_node_dir_plugins_share: /usr/lib/munin/plugins
+munin_node_dir_plugins_custom: /usr/local/munin/lib/plugins


### PR DESCRIPTION
Found this role very useful so I added Arch Linux support.
Since Arch uses Python 3 by default and Python 2 isn't installed, this assumes that part has already been taken care of so Ansible is able to work at all.

Hope you like it, and thanks!